### PR TITLE
chore: correct code block language tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 >
 > Feel free to open issues for any questions or ideas
 
-```sh
+```shell
 $ yarn add gatsby-plugin-algolia-index
 ```
 
 First add credentials to a .env file, which you won't commit. If you track this in your file, and especially if the site is open source, you will leak your admin API key. This would mean anyone is able to change anything on your Algolia index.
 
-```env
+```
 // .env.${process.env.NODE_ENV}
 ALGOLIA_APP_ID=XXX
 ALGOLIA_API_KEY=XXX


### PR DESCRIPTION
This is to silence prism highlighter warnings -- `env` is not on the list of [officially supported language tags](https://prismjs.com/#languages-list). Thanks!